### PR TITLE
Continuing on

### DIFF
--- a/custom_components/multi_zone_receiver/__init__.py
+++ b/custom_components/multi_zone_receiver/__init__.py
@@ -10,7 +10,8 @@ import logging
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_NAME
-from homeassistant.core import Config, HomeAssistant
+from homeassistant.core import HomeAssistant
+from homeassistant.core_config import Config
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.reload import async_setup_reload_service
 

--- a/custom_components/multi_zone_receiver/const.py
+++ b/custom_components/multi_zone_receiver/const.py
@@ -3,7 +3,7 @@
 # Base component constants
 NAME = "Multi Zone Receiver"
 DOMAIN = "multi_zone_receiver"
-VERSION = "0.7.6"
+VERSION = "0.7.7"
 
 ATTRIBUTION = "Data provided by http://jsonplaceholder.typicode.com/"
 ISSUE_URL = "https://github.com/jzucker2/multi-zone-receiver/issues"

--- a/custom_components/multi_zone_receiver/const.py
+++ b/custom_components/multi_zone_receiver/const.py
@@ -3,7 +3,7 @@
 # Base component constants
 NAME = "Multi Zone Receiver"
 DOMAIN = "multi_zone_receiver"
-VERSION = "0.7.7"
+VERSION = "0.8.0"
 
 ATTRIBUTION = "Data provided by http://jsonplaceholder.typicode.com/"
 ISSUE_URL = "https://github.com/jzucker2/multi-zone-receiver/issues"

--- a/custom_components/multi_zone_receiver/manifest.json
+++ b/custom_components/multi_zone_receiver/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "calculated",
   "issue_tracker": "https://github.com/jzucker2/multi-zone-receiver/issues",
   "requirements": [],
-  "version": "0.7.7"
+  "version": "0.8.0"
 }

--- a/custom_components/multi_zone_receiver/manifest.json
+++ b/custom_components/multi_zone_receiver/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "calculated",
   "issue_tracker": "https://github.com/jzucker2/multi-zone-receiver/issues",
   "requirements": [],
-  "version": "0.7.6"
+  "version": "0.7.7"
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Update HA import for Config and bump integration version to 0.8.0.
> 
> - **Integration**:
>   - Update Home Assistant imports in `custom_components/multi_zone_receiver/__init__.py` to use `Config` from `homeassistant.core_config` and `HomeAssistant` from `homeassistant.core`.
> - **Versioning**:
>   - Bump version to `0.8.0` in `custom_components/multi_zone_receiver/const.py` and `manifest.json`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b992e869c3aba57c5d579fa4cf440e7731b5c280. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->